### PR TITLE
Update Chef_Server_for_Linux_RightLink_10_v1.yml

### DIFF
--- a/server_templates/chef_server/Chef_Server_for_Linux_RightLink_10_v1.yml
+++ b/server_templates/chef_server/Chef_Server_for_Linux_RightLink_10_v1.yml
@@ -94,7 +94,7 @@ RightScripts:
   - PFT_RL10_Chef_Create_Admin_User.sh
   - PFT_RL10_Chef_Create_Org.sh
   - PFT_RL10_Chef_Credentials.sh
-  - PFT_RL10_Chef_Install_cookbooks.sh
+  - PFT_RL10_Chef_Install_Cookbooks.sh
 MultiCloudImages:
 - Name: PFT Base Linux MCI
 Alerts:


### PR DESCRIPTION
Minor fix to allow chef-server template to be created properly.